### PR TITLE
Add ability to inherit debugger providers from global config

### DIFF
--- a/lua/nvim-dap-projects.lua
+++ b/lua/nvim-dap-projects.lua
@@ -1,16 +1,6 @@
 local M = {}
 
-local defaults = {
-    inherit_adapters = false, -- inherit adapter configuration from global
-}
-
 M.config_paths = { "./.nvim-dap/nvim-dap.lua", "./.nvim-dap.lua", "./.nvim/nvim-dap.lua" }
-
-M.options = {}
-
-function M.setup(user_options)
-    M.options = vim.tbl_extend("force", defaults, user_options or {})
-end
 
 function M.search_project_config()
     if not pcall(require, "dap") then
@@ -30,11 +20,6 @@ function M.search_project_config()
         return
     end
     vim.notify("[nvim-dap-projects] Found nvim-dap configuration at." .. project_config, vim.log.levels.INFO, nil)
-
-    -- default is false to not break existing configuration
-    if not M.options.inherit_adapters then
-        require('dap').adapters = (function() return {} end)()
-    end
 
     require('dap').configurations = (function() return {} end)()
     vim.cmd(":luafile " .. project_config)

--- a/lua/nvim-dap-projects.lua
+++ b/lua/nvim-dap-projects.lua
@@ -1,6 +1,16 @@
 local M = {}
 
-M.config_paths = {"./.nvim-dap/nvim-dap.lua", "./.nvim-dap.lua", "./.nvim/nvim-dap.lua"}
+local defaults = {
+    inherit_adapters = false, -- inherit adapter configuration from global
+}
+
+M.config_paths = { "./.nvim-dap/nvim-dap.lua", "./.nvim-dap.lua", "./.nvim/nvim-dap.lua" }
+
+M.options = {}
+
+function M.setup(user_options)
+    M.options = vim.tbl_extend("force", defaults, user_options or {})
+end
 
 function M.search_project_config()
     if not pcall(require, "dap") then
@@ -20,7 +30,12 @@ function M.search_project_config()
         return
     end
     vim.notify("[nvim-dap-projects] Found nvim-dap configuration at." .. project_config, vim.log.levels.INFO, nil)
-    require('dap').adapters = (function() return {} end)()
+
+    -- default is false to not break existing configuration
+    if not M.options.inherit_adapters then
+        require('dap').adapters = (function() return {} end)()
+    end
+
     require('dap').configurations = (function() return {} end)()
     vim.cmd(":luafile " .. project_config)
 end


### PR DESCRIPTION
This changes the implementation to inherit and override global debugger adapter configuration instead of having to redefine it in the project specific config file. Since some adapters need the absolute path to the binary having it in the project local file might not be portable.

> initial implementation of replacing adapter configuration has been changed to overriding.

This change will not break existing config.

## Example
### `init.lua`
```lua filename="init.lua"
local dap = require('dap')
dap.adapters.cppdbg = {
-- global debug adapter
}

dap.configurations.rust = {
-- global debug config
}

local dap_projects = require("nvim-dap-projects")
dap_projects.search_project_config()
```

### `<project-root>/project-config.lua`
```lua filename="project-config.lua"
local dap = require('dap')
-- optional adapter configuration to be defined here
-- adapter configuration defined here will be merged
-- with the global config in init.lua

dap.configurations.rust = {
-- project specific config
}
```

## Why?
I found that certain debug config (in my case it was Rust debugging with `cppdbg`) required defining absolute path names in the adapter config. Having this detail in the project specific config is brittle since if the repo is shared, each developer will have to change that value. Git ignoring the file defeats the purpose too IMO.

## Drawbacks
> initial implementation had drawback of replacing config, but this has been updated.